### PR TITLE
Fix issue with CrystalSeekbar.apply() that caused the values set for …

### DIFF
--- a/crystalrangeseekbar/src/main/java/com/crystal/crystalrangeseekbar/widgets/CrystalSeekbar.java
+++ b/crystalrangeseekbar/src/main/java/com/crystal/crystalrangeseekbar/widgets/CrystalSeekbar.java
@@ -473,10 +473,10 @@ public class CrystalSeekbar extends View {
         //normalizedMinValue = 0d;
         //normalizedMaxValue = 100d;
 
-        thumbWidth = (thumb != null) ? thumb.getWidth() : getResources().getDimension(R.dimen.thumb_width);
-        thumbHeight = (thumb != null) ? thumb.getHeight() : getResources().getDimension(R.dimen.thumb_height);
+        thumbWidth = getThumbWidth();
+        thumbHeight = getThumbHeight();
 
-        barHeight = (thumbHeight * 0.5f) * 0.3f;
+        barHeight = getBarHeight();
         barPadding = thumbWidth * 0.5f;
 
         // set min start value


### PR DESCRIPTION
…bar_height or thumb_diameter in XML to be ignored after calling apply.